### PR TITLE
Update from `clojure.tools.nrepl.*` to `nrepl.*`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - A missing `init-ns` (e.g. `user`) no longer prints a stacktrace.
 
+### Changed
+
+- Switched from `clojure.tools.nrepl.*` to `nrepl.*`.
+
 ## 0.2.0
 
 Initial release

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:deps
  {org.clojure/clojure     {:mvn/version "1.9.0"}
-  org.clojure/tools.nrepl {:mvn/version "0.2.12"}
+  nrepl                   {:mvn/version "0.6.0"}
   org.clojure/tools.cli   {:mvn/version "0.3.5"}}
 
  :aliases

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>lambdaisland</groupId>
   <artifactId>nrepl</artifactId>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <name>lambdaisland/nrepl</name>
   <description>nREPL wrapper + main entry point</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,9 +14,9 @@
       <version>1.9.0</version>
     </dependency>
     <dependency>
-      <groupId>org.clojure</groupId>
-      <artifactId>tools.nrepl</artifactId>
-      <version>0.2.12</version>
+      <groupId>nrepl</groupId>
+      <artifactId>nrepl</artifactId>
+      <version>0.6.0</version>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>

--- a/src/lambdaisland/nrepl.clj
+++ b/src/lambdaisland/nrepl.clj
@@ -1,7 +1,7 @@
 (ns lambdaisland.nrepl
-  (:require [clojure.tools.nrepl.server :as nrepl]
-            [clojure.tools.nrepl.middleware :as nrepl-mw]
-            [clojure.tools.nrepl.middleware.session :as nrepl-mw-session]))
+  (:require [nrepl.server :as nrepl]
+            [nrepl.middleware :as nrepl-mw]
+            [nrepl.middleware.session :as nrepl-mw-session]))
 
 (def ^:dynamic *default-opts*
   {:bind "127.0.0.1"


### PR DESCRIPTION
The nrepl project has changed its namespaces, and using older ones causes problems when loading middleware (cider).